### PR TITLE
Make webchimera.js a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "type": "git",
         "url": "https://github.com/Magics-Group/wcjs-renderer"
     },
-    "optionalDependencies": {
+    "peerDependencies": {
         "webchimera.js": "latest"
     }
 }


### PR DESCRIPTION
`wcjs-renderer` can work along with `webchimera.js`, but doesn't necessarily need it. What about listing it as a peer dependency instead of an optional dependency? After all, an optional dependency is only a regular dependency that doesn't make the dependent package install fail if its install fails... 

In my case I want to use `wcjs-renderer` with `wcjs-prebuilt`, and I don't want `npm` to install `webchimera.js` as part of the install of `wcjs-renderer`. Of course I can use `npm`'s `--no-optional` flag, but that won't go into my `package.json` and so that info won't be persisted anywhere... I'd be much happier with a simple warning message telling me that peer dependency `webchimera.js` isn't met.

Just a suggestion. Not sure what the actual best practice is here...
